### PR TITLE
Make login and register forms responsive

### DIFF
--- a/src/components/LoginForm/LoginForm.module.css
+++ b/src/components/LoginForm/LoginForm.module.css
@@ -2,5 +2,6 @@
   margin-left: auto;
   margin-right: auto;
   padding-top: 0rem;
-  min-width: calc(26.25rem * var(--mantine-scale));
+  max-width: calc(26.25rem * var(--mantine-scale));
+  width: 100%;
 }

--- a/src/components/RegisterForm/RegisterForm.module.css
+++ b/src/components/RegisterForm/RegisterForm.module.css
@@ -2,5 +2,6 @@
   margin-left: auto;
   margin-right: auto;
   padding-top: 0rem;
-  min-width: calc(26.25rem * var(--mantine-scale));
+  max-width: calc(26.25rem * var(--mantine-scale));
+  width: 100%;
 }


### PR DESCRIPTION
This change makes the login and register forms responsive by updating the CSS to be mobile-first.

- The `min-width` property on the form containers is replaced with `max-width` to allow the forms to shrink on smaller screens.
- The `width` is set to `100%` to ensure the forms use the available width.