### PR TITLE
feat: add unit test for MantineLink component

### DIFF
--- a/src/components/MantineLink/MantineLink.test.tsx
+++ b/src/components/MantineLink/MantineLink.test.tsx
@@ -21,20 +21,23 @@ const loginRoute = createRoute({
   component: () => <div>Login</div>,
 });
 
+const setup = (component: any) => {
+  const testRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component,
+  });
+  const routeTree = rootRoute.addChildren([loginRoute, testRoute]);
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory(),
+  });
+  render(<RouterProvider router={router} />);
+};
+
 describe('MantineLink', () => {
   it('renders a link with the correct href', async () => {
-    const component = () => <MantineLink to="/login">Click me</MantineLink>;
-    const testRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/',
-      component,
-    });
-    const routeTree = rootRoute.addChildren([loginRoute, testRoute]);
-    const router = createRouter({
-      routeTree,
-      history: createMemoryHistory(),
-    });
-    render(<RouterProvider router={router} />);
+    setup(() => <MantineLink to="/login">Click me</MantineLink>);
 
     await waitFor(() => {
       const linkElement = screen.getByRole('link', { name: /click me/i });
@@ -44,22 +47,11 @@ describe('MantineLink', () => {
   });
 
   it('passes other props to the anchor element', async () => {
-    const component = () => (
+    setup(() => (
       <MantineLink to="/login" className="my-custom-class">
         Click me
       </MantineLink>
-    );
-    const testRoute = createRoute({
-      getParentRoute: () => rootRoute,
-      path: '/',
-      component,
-    });
-    const routeTree = rootRoute.addChildren([loginRoute, testRoute]);
-    const router = createRouter({
-      routeTree,
-      history: createMemoryHistory(),
-    });
-    render(<RouterProvider router={router} />);
+    ));
 
     await waitFor(() => {
       const linkElement = screen.getByRole('link', { name: /click me/i });

--- a/src/components/MantineLink/MantineLink.test.tsx
+++ b/src/components/MantineLink/MantineLink.test.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 import {
   createMemoryHistory,
   createRootRoute,
@@ -6,7 +7,7 @@ import {
   Outlet,
   RouterProvider,
 } from '@tanstack/react-router';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { render } from '../../../test-utils';
 import { MantineLink } from './MantineLink';
@@ -21,7 +22,7 @@ const loginRoute = createRoute({
   component: () => <div>Login</div>,
 });
 
-const setup = (component: any) => {
+const setup = (component: () => JSX.Element) => {
   const testRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/',
@@ -36,26 +37,22 @@ const setup = (component: any) => {
 };
 
 describe('MantineLink', () => {
-  it('renders a link with the correct href', async () => {
+  it('renders a link with the correct href', () => {
     setup(() => <MantineLink to="/login">Click me</MantineLink>);
 
-    await waitFor(() => {
-      const linkElement = screen.getByRole('link', { name: /click me/i });
-      expect(linkElement).toBeInTheDocument();
-      expect(linkElement).toHaveAttribute('href', '/login');
-    });
+    const linkElement = screen.getByRole('link', { name: /click me/i });
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveAttribute('href', '/login');
   });
 
-  it('passes other props to the anchor element', async () => {
+  it('passes other props to the anchor element', () => {
     setup(() => (
       <MantineLink to="/login" className="my-custom-class">
         Click me
       </MantineLink>
     ));
 
-    await waitFor(() => {
-      const linkElement = screen.getByRole('link', { name: /click me/i });
-      expect(linkElement).toHaveClass('my-custom-class');
-    });
+    const linkElement = screen.getByRole('link', { name: /click me/i });
+    expect(linkElement).toHaveClass('my-custom-class');
   });
 });

--- a/src/components/MantineLink/MantineLink.test.tsx
+++ b/src/components/MantineLink/MantineLink.test.tsx
@@ -1,0 +1,69 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import { screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { render } from '../../../test-utils';
+import { MantineLink } from './MantineLink';
+
+const rootRoute = createRootRoute({
+  component: Outlet,
+});
+
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/login',
+  component: () => <div>Login</div>,
+});
+
+describe('MantineLink', () => {
+  it('renders a link with the correct href', async () => {
+    const component = () => <MantineLink to="/login">Click me</MantineLink>;
+    const testRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component,
+    });
+    const routeTree = rootRoute.addChildren([loginRoute, testRoute]);
+    const router = createRouter({
+      routeTree,
+      history: createMemoryHistory(),
+    });
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      const linkElement = screen.getByRole('link', { name: /click me/i });
+      expect(linkElement).toBeInTheDocument();
+      expect(linkElement).toHaveAttribute('href', '/login');
+    });
+  });
+
+  it('passes other props to the anchor element', async () => {
+    const component = () => (
+      <MantineLink to="/login" className="my-custom-class">
+        Click me
+      </MantineLink>
+    );
+    const testRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/',
+      component,
+    });
+    const routeTree = rootRoute.addChildren([loginRoute, testRoute]);
+    const router = createRouter({
+      routeTree,
+      history: createMemoryHistory(),
+    });
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      const linkElement = screen.getByRole('link', { name: /click me/i });
+      expect(linkElement).toHaveClass('my-custom-class');
+    });
+  });
+});


### PR DESCRIPTION
Adds a unit test for the `MantineLink` component, which was previously untested. The test verifies that the component renders a link with the correct `href` and that it passes through other props correctly.